### PR TITLE
fixing a careless mistake in sstats-se.sh

### DIFF
--- a/bin/sstats-se.sh
+++ b/bin/sstats-se.sh
@@ -36,7 +36,7 @@ echo "Number of trimmed reads: ${TRMREAD_NB}" >> ${SAMPLE}.stats
 
 TRMREAD_LGTH=`awk 'NR==9' FastQC/${SAMPLE}_trimmed_fastqc/fastqc_data.txt | awk -F" " '{print $3}'`
 echo "Trimmed read length range (per FastQC report): ${TRMREAD_LGTH}" >> ${SAMPLE}.stats
-TRMREAD_ML=`cat ${SAMPLE}_trimmed.fq | awk '{if(NR%4==2) printf "%.0f", length($1)}' > /tmp/${SAMPLE}_readlength1.txt; sort -n /tmp/${SAMPLE}_readlength1.txt| awk ' { a[i++]=$1; } END { printf "%0.f", a[int(i/2)]; }'`
+TRMREAD_ML=`cat ${SAMPLE}_trimmed.fq | awk '{if(NR%4==2) printf "%.0f\n", length($1)}' > /tmp/${SAMPLE}_readlength1.txt; sort -n /tmp/${SAMPLE}_readlength1.txt| awk ' { a[i++]=$1; } END { printf "%0.f", a[int(i/2)]; }'`
 echo "Median length of trimmed reads: ${TRMREAD_ML}" >> ${SAMPLE}.stats
 
 TRMSAMPLE_SZE=`awk 'BEGIN{sum=0;}{if(NR%4==2){sum+=length($0);}}END{printf "%.0f", sum;}' ${SAMPLE}_trimmed.fq`


### PR DESCRIPTION
the necessary \n was inadvertently left out of the code, preventing calculation of the median read length after trimming